### PR TITLE
Support MongoDB 3.4 aggregate without cursor changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: lein2
+lein: lein
 script: lein midje
 sudo: false
 services:
@@ -12,4 +12,5 @@ addons:
     - mongodb-org-server
 jdk:
   - openjdk7
-  - oraclejdk8
+  - openjdk8
+  - openjdk11

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject monglorious "0.7.0"
+(defproject monglorious "0.8.0"
   :author "Dave Bauman"
   :description "Query MongoDB using strings!"
   :url "https://github.com/baumandm/monglorious"

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
             :distribution :repo}
 
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [instaparse "1.4.5"]
+                 [instaparse "1.4.9"]
                  [com.novemberain/monger "3.1.0"]
                  [org.clojars.frozenlock/commons-lang "3.3.0"]
                  [clj-time "0.13.0"]]
@@ -15,8 +15,8 @@
   :target-path "target/%s"
   :javac-options ["-target" "1.6" "-source" "1.6" "-Xlint:-options"]
 
-  :profiles {:dev     {:dependencies [[midje "1.8.3"]
-                                      [org.slf4j/slf4j-nop "1.7.24"]]
+  :profiles {:dev     {:dependencies [[midje "1.9.4"]
+                                      [org.slf4j/slf4j-nop "1.7.25"]]
                        :plugins      [[lein-midje "3.2.1"]
                                       [lein-kibit "0.1.3"]
                                       [jonase/eastwood "0.2.3"]

--- a/src/monglorious/transforms.clj
+++ b/src/monglorious/transforms.clj
@@ -84,7 +84,13 @@
         (fn [_ db] (mg-coll/indexes-on db collection-name))
 
         "aggregate"
-        (fn [_ db] (apply (partial mg-coll/aggregate db collection-name) args))
+        (fn [_ db] (let [[stages opts] args
+                         opts' (->> (-> opts
+                                        (or {"cursor" {}})
+                                        (clojure.walk/keywordize-keys))
+                                    (into [])
+                                    (apply concat))]
+                     (apply (partial mg-coll/aggregate db collection-name stages) opts')))
 
         "insert"
         (let [document-or-documents (first args)]

--- a/test/monglorious/transforms_test.clj
+++ b/test/monglorious/transforms_test.clj
@@ -251,8 +251,8 @@
   (fact "Monglorious aggregates using $group"
         (execute {} "testdb" "db.documents.aggregate([{ $group: { _id: '$child', total: { $sum: '$age' }} }])") => #(and (coll? %) (= 2 (count %)))
         (execute {} "testdb" "db.documents.aggregate([{ $sort: {name: 1} }])") => #(and (coll? %) (= 9 (count %)) (= "Alan" (:name (first %))))
-        (execute {} "testdb" "db.documents.aggregate([{ $sort: {name: -1} }])") => #(and (coll? %) (= 9 (count %)) (= "Zoey" (:name (first %))))
-        (execute {} "testdb" "db.documents.aggregate([{ $group: { _id: {'child': '$child', 'age': '$age'}, total: { $sum: '$age' }} }])") => #(and (coll? %) (= 7 (count %)))))
+        (execute {} "testdb" "db.documents.aggregate([{ $sort: {name: -1} }], { cursor: {} })") => #(and (coll? %) (= 9 (count %)) (= "Zoey" (:name (first %))))
+        (execute {} "testdb" "db.documents.aggregate([{ $group: { _id: {'child': '$child', 'age': '$age'}, total: { $sum: '$age' }} }], { cursor: {} })") => #(and (coll? %) (= 7 (count %)))))
 
 
 (against-background


### PR DESCRIPTION
The default value is { cursor: {} }, but custom options can be passed to the aggregate function.

https://docs.mongodb.com/manual/release-notes/3.4-compatibility/#aggregate-wo-cursor-deprecation